### PR TITLE
Add Solana Price Display

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,5 +2,6 @@
 <html>
 <body>
 Bitcoin Price: $95,674
+Solana Price: $61.23
 </body>
 </html>


### PR DESCRIPTION
This PR adds the current Solana (SOL) price display to the website.

Changes:
- Added SOL price below BTC price
- Maintained simple HTML structure
- Matched existing price format

Closes #4